### PR TITLE
Address possible vulnerability in preauth lengths in hybrid KEM

### DIFF
--- a/kexoqsecdh.c
+++ b/kexoqsecdh.c
@@ -183,6 +183,8 @@ static int kex_kem_generic_with_ec_enc(OQS_KEM *kem,
   struct sshbuf *ecdh_client_blob = NULL;
   struct sshbuf *ecdh_server_blob = NULL;
   struct sshbuf *ecdh_shared_secret;
+  size_t client_blob_len = 0;
+  size_t ecdh_part_len = 0;
   u_char hash[SSH_DIGEST_MAX_LENGTH];
   int r = SSH_ERR_INTERNAL_ERROR;
   *server_blobp = NULL;
@@ -196,6 +198,12 @@ static int kex_kem_generic_with_ec_enc(OQS_KEM *kem,
      r = SSH_ERR_SIGNATURE_INVALID;
      goto out;
      }*/
+
+  client_blob_len = sshbuf_len(client_blob);
+  if (client_blob_len < kem->length_public_key) {
+    r = SSH_ERR_SIGNATURE_INVALID;
+    goto out;
+  }
 
   /* get a pointer to the client PQC public key */
   client_pub = sshbuf_ptr(client_blob);
@@ -230,7 +238,17 @@ static int kex_kem_generic_with_ec_enc(OQS_KEM *kem,
     goto out;
   }
 
-  ecdh_client_blob = sshbuf_from(client_pub + kem->length_public_key, sshbuf_len(client_blob) - kem->length_public_key);
+  ecdh_part_len = client_blob_len - kem->length_public_key;
+  if (ecdh_part_len == 0) {
+    r = SSH_ERR_SIGNATURE_INVALID;
+    goto out;
+  }
+  ecdh_client_blob = sshbuf_from(client_pub + kem->length_public_key,
+      ecdh_part_len);
+  if (ecdh_client_blob == NULL) {
+    r = SSH_ERR_ALLOC_FAIL;
+    goto out;
+  }
   /* generate ecdh key pair, store server ecdh public key after KEM ciphertext
      as done in kex_ecdh_enc(...) */
   if ((ecdh_server_key = EC_KEY_new_by_curve_name(kex->ec_nid)) == NULL) {
@@ -295,6 +313,8 @@ static int kex_kem_generic_with_ec_dec(OQS_KEM *kem,
   struct sshbuf *ecdh_shared_secret;
   struct sshbuf *ecdh_server_blob = NULL;
   u_char hash[SSH_DIGEST_MAX_LENGTH];
+  size_t server_blob_len = 0;
+  size_t ecdh_part_len = 0;
   int r = SSH_ERR_INTERNAL_ERROR;
   *shared_secretp = NULL;
 
@@ -306,6 +326,12 @@ static int kex_kem_generic_with_ec_dec(OQS_KEM *kem,
      r = SSH_ERR_SIGNATURE_INVALID;
      goto out;
      } */
+
+    server_blob_len = sshbuf_len(server_blob);
+    if (server_blob_len < kem->length_ciphertext) {
+      r = SSH_ERR_SIGNATURE_INVALID;
+      goto out;
+    }
 
     /* get a pointer to the server PQC ciphertext */
     ciphertext = sshbuf_ptr(server_blob);
@@ -326,7 +352,17 @@ static int kex_kem_generic_with_ec_dec(OQS_KEM *kem,
 
     /* derive the ecdh shared key, using 2nd part of server_blob
        as done in kex_ecdh_dec(...) */
-    ecdh_server_blob = sshbuf_from(ciphertext + kem->length_ciphertext, sshbuf_len(server_blob) - kem->length_ciphertext);
+    ecdh_part_len = server_blob_len - kem->length_ciphertext;
+    if (ecdh_part_len == 0) {
+      r = SSH_ERR_SIGNATURE_INVALID;
+      goto out;
+    }
+    ecdh_server_blob = sshbuf_from(ciphertext + kem->length_ciphertext,
+        ecdh_part_len);
+    if (ecdh_server_blob == NULL) {
+      r = SSH_ERR_ALLOC_FAIL;
+      goto out;
+    }
 
     if ((r = kex_ecdh_dec_key_group(kex, ecdh_server_blob, kex->ec_client_key,
                                     kex->ec_group, &ecdh_shared_secret)) != 0)


### PR DESCRIPTION
Martin Ramkellyn (martin-r-dev) found during an AI-assisted exploration into crafting malformed packets to exploit an SSH server.

The use of the blob does not ensure proper lengths before being passed into the KEM handling code. This allows a possible underflow.

Example that would generate the underflow:
client_blob_len = 1567
kem->length_public_key = 1568
ecdh_part_len = 1567 - 1568 = 18446744073709551615  (size_t wrap)

Cases that Martin tested with his crafted script:
All cases below refer to message-30 (`SSH2_MSG_KEX_ECDH_INIT`) mutation for `mlkem1024nistp384-sha384`.

| Case | Declared `q_c_len` | Actual `q_c_blob` bytes sent | Helper reached | Observed behavior |
|---|---:|---:|---|---|
| Declared/actual mismatch | Very large (e.g. 1000000) | Short (e.g. 32) | No | Parser rejects early as `incomplete message [preauth]` |
| Self-consistent short blob | 799 | 799 | Yes | `OQS_KEM_encaps` fails, handshake aborts, no underflow trace |
| Near-boundary short blob | 1535 / 1536 / 1537 / 1540 / 1567 | Same as declared | Yes | `OQS_KEM_encaps` may succeed; split underflow path observed; pre-auth allocation failure and connection abort |
| Expected size | 1665 | 1665 | Yes | Normal split length (97), handshake continues normally |

Additional local observations:

- `799` repeatedly showed encapsulation failure.
- `1535` and `1540` repeatedly showed encapsulation success followed by downstream failure on malformed split handling.
- `1567` is a deterministic underflow demonstration (`ec_len` wrap).

What was observed:

- Connection-level pre-auth failures for malformed inputs.
- Listener process stayed alive across repeated mutated attempts in this setup.
- No reliable listener crash was reproduced from these packet mutations.